### PR TITLE
Closes #70 Remove redundant checks introduced by overlapping changes

### DIFF
--- a/__stash4/GenerateSingleCoinChangesTests.cs
+++ b/__stash4/GenerateSingleCoinChangesTests.cs
@@ -1,0 +1,91 @@
+using Algorithms.Problems.DynamicProgramming.CoinChange;
+
+namespace Algorithms.Tests.Problems.DynamicProgramming.CoinChange;
+
+[TestFixture]
+public class GenerateSingleCoinChangesTests
+{
+    [Test]
+    public void GenerateSingleCoinChangesTests_Success()
+    {
+        DynamicCoinChangeSolver
+            .GenerateSingleCoinChanges(6, [1, 2, 3])
+            .SequenceEqual(new[] { 3, 4, 5 })
+            .Should().BeTrue();
+
+        DynamicCoinChangeSolver
+            .GenerateSingleCoinChanges(10, [1, 2, 3, 7, 12, 15, 14])
+            .SequenceEqual(new[] { 3, 7, 8, 9 })
+            .Should().BeTrue();
+
+        DynamicCoinChangeSolver
+            .GenerateSingleCoinChanges(1, [1, 2, 3, 7, 12, 15, 14])
+            .SequenceEqual(new[] { 0 })
+            .Should().BeTrue();
+
+        DynamicCoinChangeSolver
+            .GenerateSingleCoinChanges(2, [1, 2, 3, 7, 12, 15, 14])
+            .SequenceEqual(new[] { 0, 1 })
+            .Should().BeTrue();
+    }
+
+    [Test]
+    public void GenerateSingleCoinChangesTests_ShouldThrow_CoinCannotBeLesserOrEqualZero()
+    {
+        const int coin = 0;
+        var arr = new[] { 1, 2, 3 };
+
+        Func<int[]> act = () => DynamicCoinChangeSolver.GenerateSingleCoinChanges(coin, arr);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"The coin cannot be lesser or equal to zero {nameof(coin)}.");
+    }
+
+    [Test]
+    public void GenerateSingleCoinChangesTests_ShouldThrow_CoinsArrayCannotBeEmpty()
+    {
+        const int coin = 10;
+        var coinsAsArray = Array.Empty<int>();
+
+        Func<int[]> act = () => DynamicCoinChangeSolver.GenerateSingleCoinChanges(coin, coinsAsArray);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"Coins array cannot be empty {nameof(coinsAsArray)}.");
+    }
+
+    [Test]
+    public void GenerateSingleCoinChangesTests_ShouldThrow_CoinsArrayMustContainOne()
+    {
+        const int coin = 10;
+        var coinsAsArray = new[] { 2, 3, 4 };
+
+        Func<int[]> act = () => DynamicCoinChangeSolver.GenerateSingleCoinChanges(coin, coinsAsArray);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"Coins array must contain coin 1 {nameof(coinsAsArray)}.");
+    }
+
+    [Test]
+    public void GenerateSingleCoinChangesTests_ShouldThrow_CoinsArrayCannotContainNegativeValues()
+    {
+        const int coin = 10;
+        var coinsAsArray = new[] { 1, 2, -3, 4 };
+
+        Func<int[]> act = () => DynamicCoinChangeSolver.GenerateSingleCoinChanges(coin, coinsAsArray);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"{nameof(coinsAsArray)} cannot contain numbers less than or equal to zero");
+    }
+
+    [Test]
+    public void GenerateSingleCoinChangesTests_ShouldThrow_CoinsArrayCannotContainDuplicates()
+    {
+        const int coin = 10;
+        var coinsAsArray = new[] { 1, 2, 3, 3, 4 };
+
+        Func<int[]> act = () => DynamicCoinChangeSolver.GenerateSingleCoinChanges(coin, coinsAsArray);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"Coins array cannot contain duplicates {nameof(coinsAsArray)}.");
+    }
+}

--- a/__stash4/LCABinaryLifting.js
+++ b/__stash4/LCABinaryLifting.js
@@ -1,0 +1,61 @@
+/**
+ * Author: Adrito Mukherjee
+ * Finding Lowest Common Ancestor By Binary Lifting implementation in JavaScript
+ * The technique requires preprocessing the tree in O(N log N) using dynamic programming)
+ * It can be used to find Lowest Common Ancestor of two nodes in O(log N)
+ * Tutorial on Lowest Common Ancestor: https://www.geeksforgeeks.org/lca-in-a-tree-using-binary-lifting-technique
+ */
+
+import { BinaryLifting } from './BinaryLifting'
+
+class LCABinaryLifting extends BinaryLifting {
+  constructor(root, tree) {
+    super(root, tree)
+    this.depth = new Map() // depth[node] stores the depth of node from root
+    this.depth.set(root, 1)
+    this.dfsDepth(root, root)
+  }
+
+  dfsDepth(node, parent) {
+    // DFS to find depth of every node in the tree
+    for (const child of this.connections.get(node)) {
+      if (child !== parent) {
+        this.depth.set(child, this.depth.get(node) + 1)
+        this.dfsDepth(child, node)
+      }
+    }
+  }
+
+  getLCA(node1, node2) {
+    // We make sure that node1 is the deeper node among node1 and node2
+    if (this.depth.get(node1) < this.depth.get(node2)) {
+      ;[node1, node2] = [node2, node1]
+    }
+    // We check if node1 is the ancestor of node2, and if so, then return node1
+    const k = this.depth.get(node1) - this.depth.get(node2)
+    node1 = this.kthAncestor(node1, k)
+    if (node1 === node2) {
+      return node1
+    }
+
+    for (let i = this.log - 1; i >= 0; i--) {
+      if (this.up.get(node1).get(i) !== this.up.get(node2).get(i)) {
+        node1 = this.up.get(node1).get(i)
+        node2 = this.up.get(node2).get(i)
+      }
+    }
+    return this.up.get(node1).get(0)
+  }
+}
+
+function lcaBinaryLifting(root, tree, queries) {
+  const graphObject = new LCABinaryLifting(root, tree)
+  const lowestCommonAncestors = []
+  for (const [node1, node2] of queries) {
+    const lca = graphObject.getLCA(node1, node2)
+    lowestCommonAncestors.push(lca)
+  }
+  return lowestCommonAncestors
+}
+
+export default lcaBinaryLifting

--- a/__stash4/abs.go
+++ b/__stash4/abs.go
@@ -1,0 +1,18 @@
+// abs.go
+// description: returns absolute value using binary operation
+// time complexity: O(1)
+// space complexity: O(1)
+
+package binary
+
+// Abs returns absolute value using binary operation
+// Principle of operation:
+// 1) Get the mask by right shift by the base
+// 2) Base is the size of an integer variable in bits, for example, for int32 it will be 32, for int64 it will be 64
+// 3) For negative numbers, above step sets mask as 1 1 1 1 1 1 1 1 and 0 0 0 0 0 0 0 0 for positive numbers.
+// 4) Add the mask to the given number.
+// 5) XOR of mask + n and mask gives the absolute value.
+func Abs(base, n int) int {
+	m := n >> (base - 1)
+	return (n + m) ^ m
+}

--- a/__stash4/anagram_checker.rb
+++ b/__stash4/anagram_checker.rb
@@ -1,0 +1,45 @@
+# Challenge name: Is anagram
+#
+# Given two strings s and t , write a function to determine
+# if t is an anagram of s.
+#
+# Note:
+# You may assume the string contains only lowercase alphabets.
+#
+# Follow up:
+# What if the inputs contain unicode characters?
+# How would you adapt your solution to such case?
+#
+# @param {String} s
+# @param {String} t
+# @return {Boolean}
+
+#
+# Approach: Sort and Compare
+#
+# Complexity analysis:
+#
+# Time Complexity: O(n log n). Assume that n is the length of s, sorting costs O(n log n), and comparing two strings costs O(n). Sorting time dominates and the overall time complexity is O(n log n).
+# Space Complexity: O(1). Space depends on the sorting implementation which, usually, costs O(1) auxiliary space if heapsort is used.
+#
+def is_anagram(s, t)
+  return false if s.length != t.length
+
+  arr1 = s.split('').sort
+  arr2 = t.split('').sort
+
+  arr1 == arr2
+end
+
+s = 'anagram'
+t = 'nagaram'
+puts(is_anagram(s, t))
+# => true
+s = 'rat'
+t = 'car'
+puts(is_anagram(s, t))
+# => false
+s = 'a'
+t = 'ab'
+puts(is_anagram(s, t))
+# => false

--- a/__stash4/catalannumber_test.go
+++ b/__stash4/catalannumber_test.go
@@ -1,0 +1,37 @@
+// catalannumber_test.go
+// description: Test for returns the Catalan number
+// author(s) [red_byte](https://github.com/i-redbyte)
+// see catalannumber.go
+
+package catalan
+
+import "testing"
+
+func TestCatalanNumber(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int
+		want int
+	}{
+		{"zero Catalan number ", 0, 1},
+		{"second Catalan number ", 2, 2},
+		{"third Catalan number ", 3, 5},
+		{"fourth Catalan number ", 4, 14},
+		{"fifth Catalan number ", 5, 42},
+		{"sixth Catalan number ", 6, 132},
+		{"tenth Catalan number ", 10, 16796},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := CatalanNumber(test.n); got != test.want {
+				t.Errorf("CatalanNumber() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func BenchmarkCatalanNumber(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		CatalanNumber(10)
+	}
+}

--- a/__stash4/rna_transcription.h
+++ b/__stash4/rna_transcription.h
@@ -1,0 +1,7 @@
+#ifndef __RNA_TRANSCRIPTION__H
+#define __RNA_TRANSCRIPTION__H
+
+/* to_rna: compiles a DNA strand in its RNA complement */
+char *to_rna(const char s[]);
+
+#endif


### PR DESCRIPTION
70 This issue is marked as duplicate of #2341, which describes the same TensorBoard visualization problem with custom metrics in distributed training. The original issue has been resolved in PR #2450, and users experiencing this problem should upgrade to version 2.4.0 or later where the fix is included.