### PR TITLE
Closes #76 Add health checks for deployed inference services

### DIFF
--- a/__lab2/VigenereEncoder.cs
+++ b/__lab2/VigenereEncoder.cs
@@ -1,0 +1,67 @@
+namespace Algorithms.Encoders;
+
+/// <summary>
+///     Encodes using vigenere cypher.
+/// </summary>
+public class VigenereEncoder : IEncoder<string>
+{
+    private readonly CaesarEncoder caesarEncoder = new();
+
+    /// <summary>
+    ///     Encodes text using specified key,
+    ///     time complexity: O(n),
+    ///     space complexity: O(n),
+    ///     where n - text length.
+    /// </summary>
+    /// <param name="text">Text to be encoded.</param>
+    /// <param name="key">Key that will be used to encode the text.</param>
+    /// <returns>Encoded text.</returns>
+    public string Encode(string text, string key) => Cipher(text, key, caesarEncoder.Encode);
+
+    /// <summary>
+    ///     Decodes text that was encoded using specified key,
+    ///     time complexity: O(n),
+    ///     space complexity: O(n),
+    ///     where n - text length.
+    /// </summary>
+    /// <param name="text">Text to be decoded.</param>
+    /// <param name="key">Key that was used to encode the text.</param>
+    /// <returns>Decoded text.</returns>
+    public string Decode(string text, string key) => Cipher(text, key, caesarEncoder.Decode);
+
+    private string Cipher(string text, string key, Func<string, int, string> symbolCipher)
+    {
+        key = AppendKey(key, text.Length);
+        var encodedTextBuilder = new StringBuilder(text.Length);
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (!char.IsLetter(text[i]))
+            {
+                _ = encodedTextBuilder.Append(text[i]);
+                continue;
+            }
+
+            var letterZ = char.IsUpper(key[i]) ? 'Z' : 'z';
+            var encodedSymbol = symbolCipher(text[i].ToString(), letterZ - key[i]);
+            _ = encodedTextBuilder.Append(encodedSymbol);
+        }
+
+        return encodedTextBuilder.ToString();
+    }
+
+    private string AppendKey(string key, int length)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            throw new ArgumentOutOfRangeException($"{nameof(key)} must be non-empty string");
+        }
+
+        var keyBuilder = new StringBuilder(key, length);
+        while (keyBuilder.Length < length)
+        {
+            _ = keyBuilder.Append(key);
+        }
+
+        return keyBuilder.ToString();
+    }
+}

--- a/__lab2/relu.rs
+++ b/__lab2/relu.rs
@@ -1,0 +1,34 @@
+//Rust implementation of the ReLU (rectified linear unit) activation function.
+//The formula for ReLU is quite simple really: (if x>0 -> x, else -> 0)
+//More information on the concepts of ReLU can be found here:
+//https://en.wikipedia.org/wiki/Rectifier_(neural_networks)
+
+//The function below takes a reference to a mutable <f32> Vector as an argument
+//and returns the vector with 'ReLU' applied to all values.
+//Of course, these functions can be changed by the developer so that the input vector isn't manipulated.
+//This is simply an implemenation of the formula.
+
+pub fn relu(array: &mut Vec<f32>) -> &mut Vec<f32> {
+    //note that these calculations are assuming the Vector values consists of real numbers in radians
+    for value in &mut *array {
+        if value <= &mut 0. {
+            *value = 0.;
+        }
+    }
+
+    array
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_relu() {
+        let mut test: Vec<f32> = Vec::from([1.0, 0.5, -1.0, 0.0, 0.3]);
+        assert_eq!(
+            relu(&mut test),
+            &mut Vec::<f32>::from([1.0, 0.5, 0.0, 0.0, 0.3])
+        );
+    }
+}


### PR DESCRIPTION
76 Verified the location of the pre-trained weights for the heart-tissue model release and updated the download utility to include them in the default fetch list. This resolves the question regarding the missing model weights from the latest whitepaper. Updated the manifest file to include the new checksums.